### PR TITLE
Fix python 'testing equality to none' issue

### DIFF
--- a/hfcNastran95InpInFem.py
+++ b/hfcNastran95InpInFem.py
@@ -29,7 +29,7 @@ class hfcNastran95InpInFem:
 
 	def IsActive(self):
 
-		if FreeCAD.ActiveDocument == None:
+		if FreeCAD.ActiveDocument is None:
 			return False
 		else:
 			return True

--- a/hfcNastran95OpenF06.py
+++ b/hfcNastran95OpenF06.py
@@ -26,7 +26,7 @@ class hfcNastran95OpenF06:
 
 	def IsActive(self):
 
-		#if FreeCAD.ActiveDocument == None:
+		#if FreeCAD.ActiveDocument is None:
 		#	return False
 		#else:
 		#	return True

--- a/hfcNastran95OpenInp.py
+++ b/hfcNastran95OpenInp.py
@@ -26,7 +26,7 @@ class hfcNastran95OpenInp:
 
 	def IsActive(self):
 
-		#if FreeCAD.ActiveDocument == None:
+		#if FreeCAD.ActiveDocument is None:
 		#	return False
 		#else:
 		#	return True


### PR DESCRIPTION
"When you compare an object to None, use is rather than ==. None is a singleton object, comparing using == invokes the __eq__ method on the object in question, which may be slower than identity comparison. Comparing to None using the is operator is also easier for other programmers to read."